### PR TITLE
composite: permits access to items by name

### DIFF
--- a/.style.yapf
+++ b/.style.yapf
@@ -1,3 +1,3 @@
 [style]
 based_on_style = pep8
-column_limit = 120
+column_limit = 100

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,10 @@
+# Only build master and develop on push; do not build every branch.
+branches:
+  only:
+    - master
+    - develop
+    - /^releases\/.*$/
+
 sudo: false
 language: python
 python:
@@ -7,7 +14,9 @@ python:
   - "2.6"
 
 # command to install dependencies
-install: pip install tox-travis
+install:
+  - pip install tox-travis
+  - pip install six
 
 # command to run tests
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,10 @@ branches:
 sudo: false
 language: python
 python:
+  - "3.6"
   - "3.5"
   - "3.4"
+  - "3.3"
   - "2.7"
   - "2.6"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ python:
 # command to install dependencies
 install:
   - pip install tox-travis
-  - pip install six
 
 # command to run tests
 script: tox

--- a/dpp/composite.py
+++ b/dpp/composite.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright 2016 Massimiliano Culpo
+# Copyright 2016,2017 Massimiliano Culpo
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,48 +13,112 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-Everything you need to employ the composite pattern
-"""
+
+"""Everything you need to employ the composite pattern"""
 from __future__ import absolute_import, print_function
 
-import inspect
-import collections
 import functools
+import inspect
+
+try:
+    from collections.abc import MutableSequence
+except ImportError:
+    from collections import MutableSequence
+
+import six
 
 from .inspection import is_private, is_special
 
 
-def composite(interface=None, method_list=None, container=list, reductions=None):
-    """
-    Returns a class decorator that patches a class adding all the methods it needs to be a composite for a given
-    interface.
+class _CompositeContainer(MutableSequence):
+    """Container used for the composite implementation.
 
-    :param interface: class exposing the interface to which the composite object must conform. Only non-private and
-    non-special instance methods will be patched
+    This container is basically a list that permits to append items with a
+    name, and retrieve them by name. It doesn't permit to set them by name.
+    """
+    def __init__(self):
+        self._items = []
+        self._named_items = {}
+
+    # pylint: disable = arguments-differ
+    def append(self, value, name=None):
+        """Append an item to the container. If it has a name store it to
+        permit also a look-up by name.
+
+        :param value: value to be appended
+        :param name: name to be associated with the value (optional)
+        """
+        if name is not None:
+            self._named_items[name] = value
+        super(_CompositeContainer, self).append(value)
+
+    def __contains__(self, item):
+        """Try to look-up by name first, delegate to list later."""
+        if item in self._named_items:
+            return self._named_items[item]
+
+        return super(_CompositeContainer, self).__contains__(item)
+
+    def __getitem__(self, item):
+        # If item is a string, return whatever the lookup by name gives
+        if isinstance(item, six.string_types):
+            return self._named_items[item]
+
+        # Otherwise delegate to list
+        return self._items[item]
+
+    def _cleanup_named_items(self):
+        self._named_items = dict([
+            (k, v) for k, v in self._named_items.items() if v in self._items
+        ])
+
+    def __setitem__(self, key, value):
+        # Delegate to list for setting
+        self._items[key] = value
+
+        # Cleanup the dictionary appropriately
+        self._cleanup_named_items()
+
+    def __delitem__(self, key):
+        # Delegate to list for deletion
+        del self._items[key]
+
+        # Cleanup the dictionary appropriately
+        self._cleanup_named_items()
+
+    def __len__(self):
+        return len(self._items)
+
+    def insert(self, index, value):
+        self._items.insert(index, value)
+
+
+def composite(interface=None, method_list=None, reductions=None):
+    """Returns a class decorator that patches a class adding all the methods it needs
+    to be a composite for a given interface.
+
+    :param interface: class exposing the interface to which the composite object must conform.
+        Only non-private and non-special instance methods will be patched
     :param method_list: names of methods that should be part of the composite
-    :param container: container for the composite object (default = list). Must fulfill the MutableSequence contract.
-    The composite class will expose the container API to manage object composition
     :param reductions: dictionary that maps method names to reduction function
 
     :return: class decorator
     """
-    # Check if container fulfills the MutableSequence contract and raise an exception if it doesn't
-    # The patched class returned by the decorator will inherit from the container class to expose the
-    # interface needed to manage objects composition
-    if not inspect.isclass(container) or not issubclass(container, collections.MutableSequence):
-        raise TypeError("Container must fulfill the MutableSequence contract")
-
     # Check if at least one of the 'interface' or the 'method_list' arguments are defined
     if interface is None and method_list is None:
-        raise TypeError("Either 'interface' or 'method_list' must be defined on a call to composite")
+        raise TypeError(
+            "Either 'interface' or 'method_list' must be defined on a call to composite"
+        )
 
     if reductions is not None and not isinstance(reductions, dict):
-        raise TypeError("'reduction' should be a dictionary mapping method names to reduction functions")
+        raise TypeError(
+            "'reduction' should be a dictionary mapping method names to reduction functions"
+        )
 
     def cls_decorator(cls):
         # pylint: disable=missing-docstring
-        # Retrieve the base class of the composite. Inspect its methods and decide which ones will be overridden
+        # Retrieve the base class of the composite. Inspect its methods and decide which ones
+        # will be overridden.
         def no_special_no_private(mthd):
             # Here we have a nasty difference between python 2 and python 3.
             # In python 2 x is considered to be an unbound method when coming from a class
@@ -63,12 +127,13 @@ def composite(interface=None, method_list=None, container=list, reductions=None)
             # (ismethod(x) == False, isfunction(x) == True)
             return not is_special(mthd) and not is_private(mthd)
 
-        # Patch the behavior of each of the methods in the previous list. This is done associating an instance of the
-        # descriptor below to any method that needs to be patched.
+        # Patch the behavior of each of the methods in the previous list. This is done associating
+        # an instance of the descriptor below to any method that needs to be patched.
         class IterateOver(object):
-            """
-            Descriptor used to patch methods in a composite. It iterates over all the items in the instance containing
-            the associated attribute and calls for each of them an attribute with the same name
+            """Descriptor used to patch methods in a composite.
+
+            It iterates over all the items in the instance containing the associated attribute and
+            calls for each of them an attribute with the same name.
             """
 
             # pylint: disable=too-few-public-methods
@@ -87,8 +152,9 @@ def composite(interface=None, method_list=None, container=list, reductions=None)
                             value = reduction_function(value)
                     return value
 
-                # If we are using this descriptor to wrap a method from an interface, then we must conditionally
-                # use the `functools.wraps` decorator to set the appropriate fields.
+                # If we are using this descriptor to wrap a method from an interface,
+                # then we must conditionally use the `functools.wraps` decorator to set
+                # the appropriate fields.
                 if self.func is not None:
                     getter = functools.wraps(self.func)(getter)
                 return getter
@@ -102,19 +168,20 @@ def composite(interface=None, method_list=None, container=list, reductions=None)
                 method_list_dict[name] = IterateOver(name)
             dictionary_for_type_call.update(method_list_dict)
         # Construct a dictionary with the methods inspected from the interface
-        bases = (cls, container)
+        bases = (cls, _CompositeContainer)
         if interface is not None:
-            # If an interface is passed, class methods and static methods should not be inserted in the list
-            # of methods to be wrapped
-            interface_methods = inspect.classify_class_attrs(interface)  # Get all the class attributes
-            interface_methods = [x for x in interface_methods if x.kind == 'method']  # Select only methods
+            # If an interface is passed, class methods and static methods should not be inserted
+            # in the list of methods to be wrapped
+            interface_methods = inspect.classify_class_attrs(interface)
+            interface_methods = [x for x in interface_methods if x.kind == 'method']
             interface_methods = [x for x in interface_methods if no_special_no_private(x.object)]
+
             # {name: IterateOver(name, method) for name, method in interface_methods.items()}
             interface_methods_dict = dict(
                 (item.name, IterateOver(item.name, item.object)) for item in interface_methods
             )
             dictionary_for_type_call.update(interface_methods_dict)
-            bases = (cls, interface, container)
+            bases = (cls, interface, _CompositeContainer)
 
         # Generate the new class on the fly and return it
         wrapper_class = type(cls.__name__, bases, dictionary_for_type_call)

--- a/dpp/composite.py
+++ b/dpp/composite.py
@@ -37,6 +37,7 @@ class _CompositeContainer(MutableSequence):
     name, and retrieve them by name. It doesn't permit to set them by name.
     """
     def __init__(self):
+        super(_CompositeContainer, self).__init__()
         self._items = []
         self._named_items = {}
 

--- a/dpp/composite.py
+++ b/dpp/composite.py
@@ -13,7 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 """Everything you need to employ the composite pattern"""
 from __future__ import absolute_import, print_function
 
@@ -36,6 +35,7 @@ class _CompositeContainer(MutableSequence):
     This container is basically a list that permits to append items with a
     name, and retrieve them by name. It doesn't permit to set them by name.
     """
+
     def __init__(self):
         super(_CompositeContainer, self).__init__()
         self._items = []
@@ -69,9 +69,7 @@ class _CompositeContainer(MutableSequence):
         return self._items[item]
 
     def _cleanup_named_items(self):
-        self._named_items = dict([
-            (k, v) for k, v in self._named_items.items() if v in self._items
-        ])
+        self._named_items = dict([(k, v) for k, v in self._named_items.items() if v in self._items])
 
     def __setitem__(self, key, value):
         # Delegate to list for setting
@@ -108,13 +106,11 @@ def composite(interface=None, method_list=None, reductions=None):
     # Check if at least one of the 'interface' or the 'method_list' arguments are defined
     if interface is None and method_list is None:
         raise TypeError(
-            "Either 'interface' or 'method_list' must be defined on a call to composite"
-        )
+            "Either 'interface' or 'method_list' must be defined on a call to composite")
 
     if reductions is not None and not isinstance(reductions, dict):
         raise TypeError(
-            "'reduction' should be a dictionary mapping method names to reduction functions"
-        )
+            "'reduction' should be a dictionary mapping method names to reduction functions")
 
     def cls_decorator(cls):
         # pylint: disable=missing-docstring
@@ -178,9 +174,8 @@ def composite(interface=None, method_list=None, reductions=None):
             interface_methods = [x for x in interface_methods if no_special_no_private(x.object)]
 
             # {name: IterateOver(name, method) for name, method in interface_methods.items()}
-            interface_methods_dict = dict(
-                (item.name, IterateOver(item.name, item.object)) for item in interface_methods
-            )
+            interface_methods_dict = dict((item.name, IterateOver(item.name, item.object))
+                                          for item in interface_methods)
             dictionary_for_type_call.update(interface_methods_dict)
             bases = (cls, interface, _CompositeContainer)
 

--- a/dpp/composite.py
+++ b/dpp/composite.py
@@ -29,7 +29,7 @@ import six
 from .inspection import is_private, is_special
 
 
-class _CompositeContainer(MutableSequence):
+class _CompositeContainer(MutableSequence):  # pylint: disable = too-many-ancestors
     """Container used for the composite implementation.
 
     This container is basically a list that permits to append items with a

--- a/dpp/expected.py
+++ b/dpp/expected.py
@@ -20,8 +20,13 @@ class Expected(object):
     """Descriptor that holds a value or the exception explaining
     why the value was not set
     """
+
     # pylint: disable=too-few-public-methods
-    def __init__(self, predicate, exc_cls=RuntimeError, message='Invalid value set', trigger_on_set=False):
+    def __init__(self,
+                 predicate,
+                 exc_cls=RuntimeError,
+                 message='Invalid value set',
+                 trigger_on_set=False):
         """
         Initializes the descriptor with the predicate and optional information
 

--- a/dpp/inspection.py
+++ b/dpp/inspection.py
@@ -29,7 +29,7 @@ def is_special(item):
     :param item: item to be inspected
     :return: True or False
     """
-    # TODO : this matches any __<name>__ not only the ones that are part of a protocol in the language
+    # TODO : this matches any __<name>__ not only special methods
     name = getattr(item, '__name__')
     if _IS_SPECIAL_PATTERN.match(name):
         return True

--- a/dpp/state.py
+++ b/dpp/state.py
@@ -13,24 +13,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-"""
-State pattern and common variations
-"""
+"""State pattern and common variations"""
 import inspect
 
 
 class State(object):
+    """Wrap the data for the current state and aggregate the information on transitions
+    to the next states.
     """
-    Wrap the data for the current state and aggregate the information on transitions to the next states
-    """
+
     # pylint: disable=too-few-public-methods
     def __init__(self, cls, *args):
         self.data = cls(*args)  # Wrapped object that will act as a state
-        self.transitions = {}  # Transitions from this to other states in the form {event : next_state}
+        self.transitions = {
+        }  # Transitions from this to other states in the form {event : next_state}
 
     def __getattr__(self, item):
-        """
-        If the attribute is not defined in the wrapper, delegate to the wrapped object
+        """If the attribute is not defined in the wrapper, delegate to the wrapped object.
 
         :param item: attribute requested
         :return: the attribute if it exists
@@ -51,6 +50,7 @@ class Event(object):
     """
     Represent an event that triggers a transition in the finite state machine
     """
+
     # pylint: disable=too-few-public-methods
     def __init__(self, current_state, next_state):
         self.current = current_state
@@ -61,6 +61,7 @@ class FiniteStateMachineBase(object):
     """
     Operations that are added to all finite state machines
     """
+
     # pylint: disable=too-few-public-methods
     def __call__(self, event):
         """
@@ -122,8 +123,10 @@ def fsm(interface=None, method_list=None):
         additional_attributes = {}  # Dictionary of additional attributes
         cls_attributes = inspect.classify_class_attrs(cls)  # Class attributes
         # Check the initial state
-        fsm_states = dict((item.name, item.object) for item in cls_attributes if isinstance(item.object, State))
-        fsm_events = dict((item.name, item.object) for item in cls_attributes if isinstance(item.object, Event))
+        fsm_states = dict((item.name, item.object)
+                          for item in cls_attributes if isinstance(item.object, State))
+        fsm_events = dict((item.name, item.object)
+                          for item in cls_attributes if isinstance(item.object, Event))
         additional_attributes['state'] = fsm_states.pop('__initial__')
         additional_attributes['states'] = fsm_states
         additional_attributes['events'] = fsm_events
@@ -135,4 +138,5 @@ def fsm(interface=None, method_list=None):
             fsm_states[current_state].transitions[event] = fsm_states[next_state]
 
         return type(cls.__name__, bases, additional_attributes)
+
     return cls_decorator

--- a/setup.py
+++ b/setup.py
@@ -71,6 +71,6 @@ setup(
     ],
     keywords='design-patterns development',
     packages=find_packages(exclude=['contrib', 'docs', 'tests']),
-    install_requires=['future', 'pytest'],
+    install_requires=['future', 'six'],
     package_data={}
 )

--- a/tests/test_composite.py
+++ b/tests/test_composite.py
@@ -105,6 +105,61 @@ class TestCompositeUsage:
         assert isinstance(composite_object, Base)
         assert issubclass(CompositeFromInterface, Base)
 
+    def test_get_item(self, composite_items):
+        @composite(interface=Base)
+        class CompositeFromInterface(object):
+            pass
+
+        one, two = composite_items
+        composite_object = CompositeFromInterface()
+
+        composite_object.append(one, 'one')
+        composite_object.append(two, 'two')
+
+        # Check indexed access
+        assert composite_object[0] is one
+        assert composite_object[1] is two
+
+        # Check access by name
+        assert composite_object['one'] is one
+        assert composite_object['two'] is two
+
+        # Check contains
+        assert one in composite_object
+        assert two in composite_object
+        assert 'one' in composite_object
+        assert 'two' in composite_object
+
+        # Check assignment
+        composite_object[:] = [two, one]
+
+        assert composite_object[0] is two
+        assert composite_object[1] is one
+        assert composite_object['one'] is one
+        assert composite_object['two'] is two
+
+        composite_object[:] = [two, two]
+
+        assert composite_object[0] is two
+        assert composite_object[1] is two
+        assert 'one' not in composite_object
+        assert composite_object['two'] is two
+
+        # Check deletion
+
+        assert len(composite_object) == 2
+
+        del composite_object[0]
+
+        assert len(composite_object) == 1
+        assert composite_object[0] == two
+        assert 'two' in composite_object
+
+        del composite_object[0]
+
+        assert len(composite_object) == 0
+        assert 'two' not in composite_object
+
 
 class TestCompositeFailures:
     def test_wrong_container(self):

--- a/tests/test_composite_reduction.py
+++ b/tests/test_composite_reduction.py
@@ -22,11 +22,9 @@ import abc
 
 
 class Base(future.utils.with_metaclass(abc.ABCMeta, object)):
-    @abc.abstractmethod
     def get_int(self):
         pass
 
-    @abc.abstractmethod
     def get_string(self):
         pass
 

--- a/tests/test_composite_reduction.py
+++ b/tests/test_composite_reduction.py
@@ -54,10 +54,9 @@ def composite_abstract_items():
 
 class TestCompositeReduction:
     def test_reduction(self, composite_abstract_items):
-
         class Multiplier(object):
             def __init__(self):
-                self.value=1
+                self.value = 1
 
             def __call__(self, value):
                 self.value *= value
@@ -87,6 +86,7 @@ class TestCompositeReduction:
 
     def test_wrong_reduction_type(self):
         with pytest.raises(TypeError):
+
             @composite(interface=Base, reductions=[])
             class CompositeFromAbcInterface(object):
                 pass

--- a/tests/test_expected.py
+++ b/tests/test_expected.py
@@ -20,19 +20,15 @@ import pytest
 
 
 class A(object):
-    lazy_value = expected.Expected(
-        predicate=lambda x: isinstance(x, str),
-        exc_cls=TypeError,
-        message='\'{value}\' is not of type \'str\'',
-        trigger_on_set=False
-    )
+    lazy_value = expected.Expected(predicate=lambda x: isinstance(x, str),
+                                   exc_cls=TypeError,
+                                   message='\'{value}\' is not of type \'str\'',
+                                   trigger_on_set=False)
 
-    greedy_value = expected.Expected(
-        predicate=lambda x: isinstance(x, str),
-        exc_cls=TypeError,
-        message='\'{value}\' is not of type \'str\'',
-        trigger_on_set=True
-    )
+    greedy_value = expected.Expected(predicate=lambda x: isinstance(x, str),
+                                     exc_cls=TypeError,
+                                     message='\'{value}\' is not of type \'str\'',
+                                     trigger_on_set=True)
 
 
 def test_expected():

--- a/tests/test_finite_state_machine.py
+++ b/tests/test_finite_state_machine.py
@@ -63,11 +63,9 @@ def test_semaphore():
     semaphore('go')  # Should do nothing from the current state
     assert semaphore.state == SemaphoreLight('red')
 
-
 #def test_dynamic_changes():
 #    semaphore = Semaphore()
 #    semaphore.add('blinking', state.State(BlinkingLight, 'yellow'))
 #    semaphore.add('blink', state.Event(current=('green', 'yellow', 'red'), next='blinking'))
 #    semaphore.add('no_blink', state.Event(current='blinking', next='yellow'))
 #    semaphore.commit()
-

--- a/tox.ini
+++ b/tox.ini
@@ -9,12 +9,11 @@ envlist = py{26,27,34,35}-{pytest,pylint}, coverage
 
 [testenv]
 deps =
-    pytest: pytest
-    pylint: pylint
-    six: six
+    pytest: pytest six
+    pylint: pylint six
 
 commands =
-    pytest: py.test
+    pytest: pytest
     pylint: pylint --rcfile {toxinidir}/pylint.ini dpp
 
 [testenv:coverage]

--- a/tox.ini
+++ b/tox.ini
@@ -1,16 +1,19 @@
 [tox]
-envlist = py{26,27,34,35}-{pytest,pylint}, coverage
+envlist = py26-pytest, py{27,34,35,36}-{pytest,pylint}, coverage
 
-[tox:travis]
-2.6 = py26-pytest
-2.7 = py27
-3.4 = py34
-3.5 = py35, coverage
+[travis]
+python =
+    2.6: py26-pytest
+    2.7: py27
+    3.4: py34
+    3.5: py35, coverage
+    3.6: py36
 
 [testenv]
 deps =
     pytest: pytest
     pylint: pylint
+    six
 
 commands =
     pytest: pytest
@@ -21,5 +24,6 @@ passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps = coveralls
        pytest
        six
+
 commands = coverage run --source=dpp -m py.test
            coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ envlist = py{26,27,34,35}-{pytest,pylint}, coverage
 deps =
     pytest: pytest
     pylint: pylint
+    six: six
 
 commands =
     pytest: py.test
@@ -20,5 +21,6 @@ commands =
 passenv = TRAVIS TRAVIS_JOB_ID TRAVIS_BRANCH
 deps = coveralls
        pytest
+       six
 commands = coverage run --source=dpp -m py.test
            coveralls

--- a/tox.ini
+++ b/tox.ini
@@ -10,9 +10,7 @@ envlist = py{26,27,34,35}-{pytest,pylint}, coverage
 [testenv]
 deps =
     pytest: pytest
-            six
     pylint: pylint
-            six
 
 commands =
     pytest: pytest

--- a/tox.ini
+++ b/tox.ini
@@ -9,8 +9,10 @@ envlist = py{26,27,34,35}-{pytest,pylint}, coverage
 
 [testenv]
 deps =
-    pytest: pytest six
-    pylint: pylint six
+    pytest: pytest
+            six
+    pylint: pylint
+            six
 
 commands =
     pytest: pytest


### PR DESCRIPTION
The 'composite' decorator has been modified to permit access to items by name, if they were added with a 'name=...' argument to append. Also removed the possibility to customize the composite container.